### PR TITLE
docs: real README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,39 @@
 # autsav.github.io
 
-🌐 My personal website.
+My personal portfolio site — an animated single-page portfolio built with Gatsby.
 
-This is my online home — a website where I show off the projects I've built. Like a digital business card plus a gallery of my work.
+🔗 **Live:** [autsav.github.io](https://autsav.github.io)
 
-## What it does
-- Shows who I am and what I can do
-- Links to my projects and work
-- Lives online for anyone to visit
+## Built with
+
+- [Gatsby](https://www.gatsbyjs.com/) with the [`@lekoarts/gatsby-theme-cara`](https://github.com/LekoArts/gatsby-themes) animated one-page theme
+- React · Theme UI · MDX (content) · React Helmet (SEO)
+- Plugins: PWA/offline, manifest, Google Analytics, Netlify
+- Deployed to **GitHub Pages** (`gh-pages` branch)
+
+## Getting started
+
+```bash
+npm install
+npm run develop        # local dev at http://localhost:8000
+```
+
+### Scripts
+
+| Command | Description |
+|---|---|
+| `npm run develop` | Gatsby dev server |
+| `npm run build` | Production build (`public/`) |
+| `npm run serve` | Serve the production build |
+| `npm run clean` | Clear the Gatsby cache |
+| `npm run deploy` | Build with path prefix and publish to `gh-pages` |
+
+## Editing content
+
+Section content (intro, projects, about, contact) lives in the `src/` MDX/Theme-UI
+overrides of `gatsby-theme-cara`. Edit those to update the site.
+
+## Deployment
+
+`npm run deploy` builds the site and pushes `public/` to the `gh-pages` branch, which
+serves [autsav.github.io](https://autsav.github.io).


### PR DESCRIPTION
## What
Replaces the placeholder README with a real one for the Gatsby portfolio: stack
(`@lekoarts/gatsby-theme-cara`), local setup, scripts, where to edit content, and the
`gh-pages` deploy flow.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)